### PR TITLE
Try replacing the widthAnchor of our labels with leadingAnchor and tr…

### DIFF
--- a/Auto-Layout-Code-P6/ViewController.swift
+++ b/Auto-Layout-Code-P6/ViewController.swift
@@ -65,8 +65,15 @@ class ViewController: UIViewController {
         
         
         for label in [label1, label2, label3, label4, label5] {
-            label.widthAnchor.constraint(equalTo: view.widthAnchor).isActive = true
-            label.heightAnchor.constraint(equalToConstant: 88).isActive = true
+            // label.widthAnchor.constraint(equalTo: view.widthAnchor).isActive = true
+            label.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
+            label.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
+            //label.safeAreaLayoutGuide.constraintsAffectingLayout(for: .horizontal)
+            //label.safeAreaLayoutGuide.constraintsAffectingLayout(for: .vertical)
+            //label.heightAnchor.constraint(equalToConstant: 88).isActive = true
+            //label.heightAnchor.constraint(equalToConstant: 1/5).isActive = true
+            label.widthAnchor.constraint(equalTo: view.safeAreaLayoutGuide.widthAnchor, multiplier: 0.5, constant: 50).isActive = true
+
             
             if let previous = previous {
                 label.topAnchor.constraint(equalTo: previous.bottomAnchor, constant: 10).isActive = true


### PR DESCRIPTION
…ailingAnchor constraints, which more explicitly pin the label to the edges of its parent.

Once you’ve completed the first challenge, try using the safeAreaLayoutGuide for those constraints. You can see if this is working by rotating to landscape, because the labels won’t go under the safe area.
Try making the height of your labels equal to 1/5th of the main view, minus 10 for the spacing. This is a hard one, but I’ve included hints below!